### PR TITLE
Add repo setup for TDengine Ansible role

### DIFF
--- a/tdengine-ansible/README.md
+++ b/tdengine-ansible/README.md
@@ -13,6 +13,8 @@ This project provides Ansible playbooks and roles for deploying a three-node TDe
 1. Install Ansible on your control machine.
 2. Update the inventory under `inventories/<env>/hosts` with the real host IPs or names.
 3. Set environment-specific variables in `inventories/<env>/group_vars/all.yml`.
+4. Ensure target hosts can reach the official TDengine repository. The role
+   automatically adds the apt repository and installs the package.
 
 ### Deploy
 

--- a/tdengine-ansible/roles/tdengine/tasks/install.yml
+++ b/tdengine-ansible/roles/tdengine/tasks/install.yml
@@ -1,4 +1,21 @@
 ---
+- name: Add TDengine apt repository key
+  apt_key:
+    url: https://repos.taosdata.com/TDengine-release/TDengine-GPG-KEY-public
+    state: present
+  become: yes
+
+- name: Add TDengine apt repository
+  apt_repository:
+    repo: "deb [arch=amd64] https://repos.taosdata.com/TDengine-release/ stable main"
+    state: present
+  become: yes
+
+- name: Update apt cache
+  apt:
+    update_cache: yes
+  become: yes
+
 - name: Install tdengine package
   apt:
     name: tdengine


### PR DESCRIPTION
## Summary
- configure apt repository and key before installing TDengine
- document repository requirement in README

## Testing
- `ansible-playbook tdengine-ansible/playbooks/deploy.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686539a12cdc8329b548c307bfee3a45