### PR TITLE
Add FQDN config and cluster check script

### DIFF
--- a/scripts/check_cluster.sh
+++ b/scripts/check_cluster.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Simple network validation for TDengine cluster
+# Usage: ./check_cluster.sh host1 host2 ...
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 host1 [host2 ...]" >&2
+  exit 1
+fi
+
+for host in "$@"; do
+  echo "Checking $host..."
+  if ! ping -c 1 "$host" >/dev/null 2>&1; then
+    echo "Error: cannot reach $host" >&2
+  else
+    echo "$host reachable"
+  fi
+  nc -z "$host" 6030 >/dev/null 2>&1 && echo "port 6030 open on $host" || echo "port 6030 closed on $host"
+  echo
+done

--- a/tdengine-ansible/README.md
+++ b/tdengine-ansible/README.md
@@ -13,6 +13,9 @@ This project provides Ansible playbooks and roles for deploying a three-node TDe
 1. Install Ansible on your control machine.
 2. Update the inventory under `inventories/<env>/hosts` with the real host IPs or names.
 3. Set environment-specific variables in `inventories/<env>/group_vars/all.yml`.
+   At minimum define `tdengine_root_pwd`, `tdengine_first_ep` and
+   `tdengine_server_port`. Optionally set `tdengine_fqdn` per host in the
+   inventory file if the inventory names are not fully qualified domain names.
 
 ### Deploy
 

--- a/tdengine-ansible/inventories/alpha/group_vars/all.yml
+++ b/tdengine-ansible/inventories/alpha/group_vars/all.yml
@@ -1,1 +1,3 @@
 tdengine_root_pwd: "alpha_pass"
+tdengine_first_ep: h1.taosdata.com
+tdengine_server_port: 6030

--- a/tdengine-ansible/inventories/alpha/hosts
+++ b/tdengine-ansible/inventories/alpha/hosts
@@ -1,4 +1,4 @@
 [tdengine]
-node1-alpha ansible_host=10.0.0.1
-node2-alpha ansible_host=10.0.0.2
-node3-alpha ansible_host=10.0.0.3
+node1-alpha ansible_host=10.0.0.1 tdengine_fqdn=h1.taosdata.com
+node2-alpha ansible_host=10.0.0.2 tdengine_fqdn=h2.taosdata.com
+node3-alpha ansible_host=10.0.0.3 tdengine_fqdn=h3.taosdata.com

--- a/tdengine-ansible/inventories/beta/group_vars/all.yml
+++ b/tdengine-ansible/inventories/beta/group_vars/all.yml
@@ -1,1 +1,3 @@
 tdengine_root_pwd: "beta_pass"
+tdengine_first_ep: h1.taosdata.com
+tdengine_server_port: 6030

--- a/tdengine-ansible/inventories/beta/hosts
+++ b/tdengine-ansible/inventories/beta/hosts
@@ -1,4 +1,4 @@
 [tdengine]
-node1-beta ansible_host=10.0.1.1
-node2-beta ansible_host=10.0.1.2
-node3-beta ansible_host=10.0.1.3
+node1-beta ansible_host=10.0.1.1 tdengine_fqdn=h1.taosdata.com
+node2-beta ansible_host=10.0.1.2 tdengine_fqdn=h2.taosdata.com
+node3-beta ansible_host=10.0.1.3 tdengine_fqdn=h3.taosdata.com

--- a/tdengine-ansible/roles/tdengine/templates/tdengine.conf.j2
+++ b/tdengine-ansible/roles/tdengine/templates/tdengine.conf.j2
@@ -1,4 +1,5 @@
 # Example tdengine configuration
 serverPort = {{ tdengine_server_port | default(6030) }}
-firstEp = {{ tdengine_first_ep | default(groups['tdengine'][0]) }}:6030
+firstEp = {{ tdengine_first_ep | default(groups['tdengine'][0]) }}:{{ tdengine_server_port | default(6030) }}
+fqdn = {{ tdengine_fqdn | default(inventory_hostname) }}
 rootPwd = {{ tdengine_root_pwd | default('taosdata') }}


### PR DESCRIPTION
## Summary
- support configuring FQDN in tdengine.conf template
- document new variables in README
- define example inventory variables
- add network validation helper script

## Testing
- `ansible-playbook --syntax-check tdengine-ansible/playbooks/deploy.yml` *(fails: command not found)*
- `./scripts/check_cluster.sh localhost`

------
https://chatgpt.com/codex/tasks/task_b_68653d36d7c8832997a8d4acc86b1664